### PR TITLE
Support default ports and create file system location

### DIFF
--- a/django_migrations_ci/backends/mysql.py
+++ b/django_migrations_ci/backends/mysql.py
@@ -5,10 +5,7 @@ from django_migrations_ci import shell
 
 def dump(connection, output_file):
     ctx, env = _ctx(connection.settings_dict)
-    if ctx['port'] == "":
-        mysqldump = "mysqldump -h {host} -u {user} {database} --result-file {output_file}"  # noqa: E501
-    else:
-        mysqldump = "mysqldump -h {host} -P {port} -u {user} {database} --result-file {output_file}"  # noqa: E501
+    mysqldump = "mysqldump -h {host} -P {port} -u {user} --result-file {output_file} {database}"  # noqa: E501
     shell.exec(mysqldump.format(output_file=output_file, **ctx), env)
 
 
@@ -30,7 +27,7 @@ def _ctx(db_conf):
 
     data = {
         "host": db_conf["HOST"],
-        "port": db_conf["PORT"],
+        "port": db_conf["PORT"] or 3306,
         "user": db_conf["USER"],
         "database": database,
     }

--- a/django_migrations_ci/backends/mysql.py
+++ b/django_migrations_ci/backends/mysql.py
@@ -6,9 +6,9 @@ from django_migrations_ci import shell
 def dump(connection, output_file):
     ctx, env = _ctx(connection.settings_dict)
     if ctx['port'] == "":
-        mysqldump = "mysqldump -h {host} -u {user} --databases {database} --result-file {output_file}"  # noqa: E501
+        mysqldump = "mysqldump -h {host} -u {user} {database} --result-file {output_file}"  # noqa: E501
     else:
-        mysqldump = "mysqldump -h {host} -P {port} -u {user} --databases {database} --result-file {output_file}"  # noqa: E501
+        mysqldump = "mysqldump -h {host} -P {port} -u {user} {database} --result-file {output_file}"  # noqa: E501
     shell.exec(mysqldump.format(output_file=output_file, **ctx), env)
 
 

--- a/django_migrations_ci/backends/mysql.py
+++ b/django_migrations_ci/backends/mysql.py
@@ -5,7 +5,10 @@ from django_migrations_ci import shell
 
 def dump(connection, output_file):
     ctx, env = _ctx(connection.settings_dict)
-    mysqldump = "mysqldump -h {host} -P {port} -u {user} --databases {database} --result-file {output_file}"  # noqa: E501
+    if ctx['port'] == "":
+        mysqldump = "mysqldump -h {host} -u {user} --databases {database} --result-file {output_file}"  # noqa: E501
+    else:
+        mysqldump = "mysqldump -h {host} -P {port} -u {user} --databases {database} --result-file {output_file}"  # noqa: E501
     shell.exec(mysqldump.format(output_file=output_file, **ctx), env)
 
 

--- a/django_migrations_ci/backends/postgresql.py
+++ b/django_migrations_ci/backends/postgresql.py
@@ -3,7 +3,7 @@ from django_migrations_ci import shell
 
 def dump(connection, output_file):
     ctx, env = _ctx(connection.settings_dict)
-    pg_dump = "pg_dump --no-owner --inserts -h {host} -p {port} -U {user} -d {database} -f {output_file}"  # noqa: E501
+    pg_dump = "pg_dump --no-owner --inserts -h {host} -p {port} -U {user} -f {output_file} {database}"  # noqa: E501
     shell.exec(pg_dump.format(output_file=output_file, **ctx), env)
 
 
@@ -21,7 +21,7 @@ def _ctx(db_conf):
 
     data = {
         "host": db_conf["HOST"],
-        "port": db_conf["PORT"],
+        "port": db_conf["PORT"] or 5432,
         "user": db_conf["USER"],
         "database": database,
     }

--- a/django_migrations_ci/management/commands/migrateci.py
+++ b/django_migrations_ci/management/commands/migrateci.py
@@ -64,18 +64,15 @@ class Command(BaseCommand):
             parallel = int(parallel)
 
         storage_class = get_storage_class(storage_class)
-        if location:
+        default_storage_class = get_storage_class(
+            "django.core.files.storage.FileSystemStorage"
+        )
+        if issubclass(storage_class, default_storage_class):
+            if not location:
+                location = "~/.migrateci"
             location_path = Path(location).expanduser()
             location_path.mkdir(parents=True, exist_ok=True)
             location = str(location_path)
-        else:
-            default_storage_class = get_storage_class(
-                "django.core.files.storage.FileSystemStorage"
-            )
-            if issubclass(storage_class, default_storage_class):
-                location_path = Path("~/.migrateci").expanduser()
-                location_path.mkdir(parents=True, exist_ok=True)
-                location = str(location_path)
 
         if verbosity >= 2:
             logger.info(f"Using storage {storage_class=} on {location=}.")

--- a/django_migrations_ci/management/commands/migrateci.py
+++ b/django_migrations_ci/management/commands/migrateci.py
@@ -65,7 +65,9 @@ class Command(BaseCommand):
 
         storage_class = get_storage_class(storage_class)
         if location:
-            location = str(Path(location).expanduser())
+            location_path = Path(location).expanduser()
+            location_path.mkdir(parents=True, exist_ok=True)
+            location = str(location_path)
         else:
             default_storage_class = get_storage_class(
                 "django.core.files.storage.FileSystemStorage"


### PR DESCRIPTION
The following changes are included in this pull request:

1. If the the port of the database configuration is empty ([django doc](https://docs.djangoproject.com/en/stable/ref/settings/#port)), remove the `port` argument from the mysql dump command.
2. If the location directory path does not exists, it will be created now.
3. Removed the creation of databases from the export by removing the `databases` argument from the mysql dump command. This is not necessary because the cursor already uses the correct database and it may cause problems if you import the dump to a database with a different name.

If this pull request is accepted, we would be happy about a new release on [pypi](https://pypi.org/).

These changes were suggested by @tobiasfunke1.