### PR TITLE
Update shell test regex to support macOS development

### DIFF
--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -9,7 +9,7 @@ def test_shell_ok():
 
 
 def test_shell_error():
-    with pytest.raises(shell.MigrateCIShellException, match="/bin/sh: 1: oof: not found\n"):
+    with pytest.raises(shell.MigrateCIShellException, match=r"oof.+not found"):
         shell.exec("oof")
 
 


### PR DESCRIPTION
Fixes #45 because the default shell on macOS returns `/bin/sh: oof: command not found\n` which doesn't quite match the regex provided.

After discussion with @iurisilvio, using a fairly lax regex which just looks for "oof" followed by "not found" is good enough.