### PR TITLE
Add explicit support for Django 4.2 to the test matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{310,311}-dj{31,32,40,41,latest}-{mysql,postgresql,sqlite},lint
+envlist = py{310,311}-dj{31,32,40,41,42,latest}-{mysql,postgresql,sqlite},lint
 
 [testenv]
 allowlist_externals = poetry
@@ -14,6 +14,7 @@ commands =
     dj32: poetry run pip install "Django>=3.2,<4.0"
     dj40: poetry run pip install "Django>=4.0,<4.1"
     dj41: poetry run pip install "Django>=4.1,<4.2"
+    dj42: poetry run pip install "Django>=4.2,<5.0"
     latest: poetry run pip install -U Django
     poetry run pytest --cov-report xml:coverage{envname}.xml
 


### PR DESCRIPTION
This way, when Django 5.0 comes out in ~2 weeks, the repo will be able to test both.