### PR TITLE
Add support for Python 3.12 and Django 5.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     services:
       postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry.dependencies]
-python = "^3.7"
-django = "^3 || ^4"
+python = "^3.10"
+django = "^4 || ^5"
 
 [tool.poetry.group.dev.dependencies]
 mysqlclient = "^2.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 django = "^4 || ^5"
 
 [tool.poetry.group.dev.dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{310,311}-dj{31,32,40,41,42,latest}-{mysql,postgresql,sqlite},lint
+envlist = py{310,311}-dj{31,32,40,41,42,50,latest}-{mysql,postgresql,sqlite},lint,py312-dj{50,latest}
 
 [testenv]
 allowlist_externals = poetry
@@ -15,6 +15,7 @@ commands =
     dj40: poetry run pip install "Django>=4.0,<4.1"
     dj41: poetry run pip install "Django>=4.1,<4.2"
     dj42: poetry run pip install "Django>=4.2,<5.0"
+    dj50: poetry run pip install "Django>=5.0,<5.1"
     latest: poetry run pip install -U Django
     poetry run pytest --cov-report xml:coverage{envname}.xml
 
@@ -34,3 +35,4 @@ commands =
 python =
     3.10: py310
     3.11: py311
+    3.12: py312


### PR DESCRIPTION
Django 5.0 adds support for Python 3.12, so we should include that in the test matrix.

Django's docs recommend dropping support for 4.0 and 4.1 here too, but that will come in a future PR if desired.