### PR TITLE
Add `--checksum` option to print the project's current checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ options:
   --location LOCATION
   --pytest
   --depth DEPTH
+  --checksum            Prints the current checksum and exits.
   -v {0,1,2,3}
 ```
 

--- a/django_migrations_ci/management/commands/migrateci.py
+++ b/django_migrations_ci/management/commands/migrateci.py
@@ -38,6 +38,13 @@ class Command(BaseCommand):
         )
         parser.add_argument("--depth", type=int, default=settings.depth)
         parser.add_argument("--reuse-db", action="store_true", default=False)
+        parser.add_argument(
+            "--checksum",
+            dest="only_print_checksum",
+            action="store_true",
+            default=False,
+            help="Prints the current checksum and exits."
+        )
 
     def _setup_logging(self):
         lib_logger = logging.getLogger("django_migrations_ci")
@@ -54,6 +61,7 @@ class Command(BaseCommand):
         depth,
         verbosity,
         reuse_db,
+        only_print_checksum,
         **options,
     ):
         self._setup_logging()
@@ -87,7 +95,13 @@ class Command(BaseCommand):
 
         current_checksum = None
         checksums = django.hash_files(depth)
+
         for cached_checksum in checksums:
+            # If run with --checksum, print the current checksum and exit.
+            if only_print_checksum:
+                self.stdout.write(cached_checksum)
+                return 0
+
             # Current checksum is the first result returned from hash_files.
             if current_checksum is None:
                 current_checksum = cached_checksum

--- a/tests/test_migrateci_command.py
+++ b/tests/test_migrateci_command.py
@@ -35,6 +35,7 @@ def cli(
     depth=None,
     reuse_db=False,
     verbosity=None,
+    checksum=None,
 ):
     args = ["manage.py", "migrateci"]
     if parallel is not None:
@@ -51,6 +52,8 @@ def cli(
         args.append(f"--depth={depth}")
     if reuse_db:
         args.append("--reuse-db")
+    if checksum:
+        args.append("--checksum")
 
     execute_from_command_line(args)
 
@@ -131,6 +134,13 @@ def test_migrateci_reuse_db(mocker, tmpdir):
     load_spy = mocker.spy(django, "load")
     cli(location=tmpdir, reuse_db=True)
     load_spy.assert_not_called()
+
+
+def test_checksum(capsys, mocker, tmpdir):
+    cli(location=tmpdir, checksum=True)
+    result = capsys.readouterr()
+    assert result.out.strip() == CHECKSUM_0002
+    assert not result.err
 
 
 class StorageSpy(FileSystemStorage):


### PR DESCRIPTION
This option lets users get the current checksum of the project without performing any operations. This can be useful to generate a cache key in CI platforms to bundle databases dumps with other artifacts like coverage reports.


Example:
```bash
$ python manage.py migrateci --checksum
8c1c0190533e18f1e694d8b0be5c46ad
```