### PR TITLE
Propagate env variables to shell subprocess to respect `PATH`

### DIFF
--- a/django_migrations_ci/shell.py
+++ b/django_migrations_ci/shell.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from subprocess import PIPE, Popen
 
 logger = logging.getLogger(__name__)
@@ -10,13 +11,18 @@ class MigrateCIShellException(Exception):
 
 def exec(command, env=None):
     logger.info(f"Running shell command {command}")
+
+    subprocess_env = os.environ.copy()
+    if env:
+        subprocess_env.update(env)
+
     p = Popen(
         command,
         shell=True,
         stdin=PIPE,
         stdout=PIPE,
         stderr=PIPE,
-        env=env,
+        env=subprocess_env,
     )
     stdout, stderr = p.communicate()
     if stderr:


### PR DESCRIPTION
Fix #56.