### PR TITLE
fix #59: cannot import name `get_storage_class` (Django 5.1)

### DIFF
--- a/django_migrations_ci/management/commands/migrateci.py
+++ b/django_migrations_ci/management/commands/migrateci.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 
+from django.conf import settings as django_settings
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.module_loading import import_string
 
@@ -71,11 +72,11 @@ class Command(BaseCommand):
         elif parallel is not None:
             parallel = int(parallel)
 
-        if hasattr(settings, "STORAGES") and "default" in settings.STORAGES:
-            default_file_storage = settings.STORAGES["default"].get("BACKEND", "django.core.files.storage.FileSystemStorage")
+        if hasattr(django_settings, "STORAGES") and "default" in django_settings.STORAGES:
+            default_file_storage = django_settings.STORAGES["default"].get("BACKEND", "django.core.files.storage.FileSystemStorage")
         else:
             # Django < 5.0
-            default_file_storage = getattr(settings, "DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage")
+            default_file_storage = getattr(django_settings, "DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage")
 
         storage_class = import_string(storage_class or default_file_storage)
         default_storage_class = import_string(

--- a/django_migrations_ci/management/commands/migrateci.py
+++ b/django_migrations_ci/management/commands/migrateci.py
@@ -1,8 +1,8 @@
 import logging
 from pathlib import Path
 
-from django.core.files.storage import get_storage_class
 from django.core.management.base import BaseCommand, CommandError
+from django.utils.module_loading import import_string
 
 try:
     from django.test.runner import get_max_test_processes  # type: ignore[attr-defined]
@@ -71,8 +71,8 @@ class Command(BaseCommand):
         elif parallel is not None:
             parallel = int(parallel)
 
-        storage_class = get_storage_class(storage_class)
-        default_storage_class = get_storage_class(
+        storage_class = import_string(storage_class or settings.DEFAULT_FILE_STORAGE)
+        default_storage_class = import_string(
             "django.core.files.storage.FileSystemStorage",
         )
         if issubclass(storage_class, default_storage_class):

--- a/django_migrations_ci/management/commands/migrateci.py
+++ b/django_migrations_ci/management/commands/migrateci.py
@@ -71,7 +71,13 @@ class Command(BaseCommand):
         elif parallel is not None:
             parallel = int(parallel)
 
-        storage_class = import_string(storage_class or settings.DEFAULT_FILE_STORAGE)
+        if hasattr(settings, "STORAGES") and "default" in settings.STORAGES:
+            default_file_storage = settings.STORAGES["default"].get("BACKEND", "django.core.files.storage.FileSystemStorage")
+        else:
+            # Django < 5.0
+            default_file_storage = getattr(settings, "DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage")
+
+        storage_class = import_string(storage_class or default_file_storage)
         default_storage_class = import_string(
             "django.core.files.storage.FileSystemStorage",
         )


### PR DESCRIPTION
The `get_storage_class` function has been removed in Django 5.1

https://docs.djangoproject.com/en/5.1/releases/5.1/