### PR TITLE
Add support for Python 3.14 and Django 6.0

### DIFF
--- a/.github/workflows/example-test.yml
+++ b/.github/workflows/example-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         pytest-django: ["<4.7", ">=4.7"]
 
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     services:
       postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django = "^4 || ^5"
+django = "^4 || ^5 || ^6"
 
 [tool.poetry.group.dev.dependencies]
 mysqlclient = "^2.1.1"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{310,311}-dj{32,42,50,51,52,latest}-{mysql,postgresql,sqlite},lint,mypy,py{312,313}-dj{50,51,52,latest}
+envlist = py{310,311}-dj{32,42,50,51,52,latest}-{mysql,postgresql,sqlite},lint,mypy,py{312,313}-dj{50,51,52,60,latest},py314-dj{60,latest}
 
 [testenv]
 allowlist_externals = poetry
@@ -15,6 +15,7 @@ commands =
     dj50: poetry run pip install "Django>=5.0,<5.1"
     dj51: poetry run pip install "Django>=5.1,<5.2"
     dj52: poetry run pip install "Django>=5.2,<5.3"
+    dj60: poetry run pip install "Django>=6.0,<6.1"
     djlatest: poetry run pip install -U Django
     poetry run pytest --cov-report xml:coverage{envname}.xml
 
@@ -44,3 +45,4 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314


### PR DESCRIPTION
Django 6.0 (released December 2025) supports Python 3.12, 3.13, and 3.14. This PR extends the test matrix accordingly:

- Add dj60 tox environments for Python 3.12 and 3.13, which already support Django 5.x

- Add a new py314 tox environment running against Django 6.0 and latest, since Python 3.14 is only supported from Django 6.0 onwards

- Update the django dependency constraint in [pyproject.toml](https://github.com/businho/django-migrations-ci/blob/main/pyproject.toml) to also allow ^6

- Add Python 3.14 to the GitHub Actions CI matrix

Fixes #63 